### PR TITLE
Allow to replace patterns in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Sync <readme.md> to Dockerhub
 
 ```
 
+Optionally, you can replace strings in your readme file. For example, to avoid broken images, you can exchange relative image URLs like `![MyImage](./doc/image.svg)` with absolute URLs like `![MyImage](https://github.com/myuser/myrepo/raw/main/doc/image.svg))`:
+
+```yaml
+- name: Sync
+  uses: ms-jpq/sync-dockerhub-readme@v1
+  with:
+    username: <dockerhub username>
+    password: <dockerhub password>
+    repository: <dockerhub name/repo>
+    readme: "./README.md"
+    replace_pattern: "](./"
+    replace_with: "](${{ github.server_url }}/${{ github.repository }}/raw/${{ github.ref_name }}/"
+```
+
 ## Docker Image
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/msjpq/sync-dockerhub-readme.svg)](https://hub.docker.com/r/msjpq/sync-dockerhub-readme/)

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,20 @@ inputs:
       list of repositories to update
       (without username)
 
+  replace_pattern:
+    required: False
+    description: |-
+      if set, all occurences of "replace_pattern" 
+      will be replaced with "replace_with"
+    default: ''
+
+  replace_with:
+    required: False
+    description: |-
+      if set, all occurences of "replace_pattern" 
+      will be replaced with "replace_with"
+    default: ''
+
 runs:
   using: docker
   image: "Dockerfile"
@@ -37,6 +51,10 @@ runs:
     - "${{ inputs.readme }}"
     - "--repo"
     - "${{ inputs.repository }}"
+    - "--replace-pattern"
+    - "${{ inputs.replace_pattern }}"
+    - "--replace-with"
+    - "${{ inputs.replace_with }}"
 
 branding:
   icon: anchor

--- a/docker_readme.py
+++ b/docker_readme.py
@@ -30,6 +30,8 @@ def parse_args() -> Namespace:
 
     parser.add_argument("--readme", required=True)
     parser.add_argument("--repo", required=True)
+    parser.add_argument("--replace-pattern", type=str, required=False)
+    parser.add_argument("--replace-with", type=str, required=False)
 
     args = parser.parse_args()
     return args
@@ -66,9 +68,16 @@ def set_repo(token: str, repo: str, readme: str) -> str:
         return loads(msg)["full_description"]
 
 
+def replace_patterns(readme: str, replace_pattern: str, replace_with: str) -> str:
+    return readme.replace(replace_pattern, replace_with)
+
+
 def main() -> None:
     args = parse_args()
+    print(args)
     readme = slurp(args.readme)
+    if args.replace_pattern and args.replace_with:
+        readme = replace_patterns(readme, args.replace_pattern, args.replace_with)
     token = login(args.username, args.password)
     desc = set_repo(token=token, repo=args.repo, readme=readme,)
     big_print(desc)


### PR DESCRIPTION
Pushing your readme to Docker Hub will break various URLs. This allows you to replace strings with a replacement pattern. An example is included for fixing broken images.

If the new parameters are not defined, the action works just like before.